### PR TITLE
cmd_windows: return *exec.ExitError on non-zero exit

### DIFF
--- a/cmd_windows.go
+++ b/cmd_windows.go
@@ -209,6 +209,9 @@ func (c *Cmd) wait() (retErr error) {
 	if retErr != nil {
 		return retErr
 	}
+	if !c.ProcessState.Success() {
+		retErr = &exec.ExitError{ProcessState: c.ProcessState}
+	}
 	return
 }
 


### PR DESCRIPTION
Closes #44.

Cmd.Wait on Windows just delegated to \`Process.Wait\`, which only surfaces a syscall error. The Unix side wraps \`exec.Cmd\` so the standard \"check \`Wait()\` error for \`*exec.ExitError\`\" pattern worked there. On Windows the ExitCode in ProcessState was populated correctly but Wait still returned nil, so callers had to look at the ProcessState directly to notice a failure.

Match \`exec.Cmd\`'s Windows behaviour: after Process.Wait succeeds, check \`ProcessState.Success()\` and surface an \`*exec.ExitError\` when it isn't. Repro from the issue (\`cmd /c exit 42\`) now returns an error you can \`errors.As\` into \`*exec.ExitError\`.